### PR TITLE
Disable JSON parsing. Convert tabs to 4 spaces.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1198,11 +1198,15 @@ int main(int argc, const char *argv[]) {
 		}
 	}
 	// end argv[] reading
-    */
+
+	// disabled for now - the parser hasn't been tested.
+	// hoche 21 Jun 2023
     if (sr.json) {
         Json json(*em_p, sr);
         json.WriteJSON(args, tx_site[0], lrp, mapfile);
     }
+    */
+
     //=====================
 
     /* That's all, folks! */


### PR DESCRIPTION
The command JSON parser hasn't been fully tested, and trying to use its results is causing the build to break. Disabling it for now.

Also, convert tabs in the code to 4 spaces.