### PR TITLE
Allow TX and RX sites to be specified in MSL

### DIFF
--- a/docs/english/splat.man
+++ b/docs/english/splat.man
@@ -70,6 +70,8 @@ splat
 .br
 [-imperial]
 .br
+[-msl]
+.br
 [-olditm]
 .SH DESCRIPTION
 \fBSPLAT!\fP is a powerful terrestrial RF propagation and terrain
@@ -185,12 +187,14 @@ sites analyzed by the program from ASCII files having a \fI.qth\fP extension.
 QTH files contain the site's name, the site's latitude (positive if North
 of the equator, negative if South), the site's longitude (in degrees West,
 0 to 360 degrees, or degrees East 0 to -360 degrees), and the site's
-antenna height above ground level (AGL), each separated by a single
-line-feed character.  The antenna height is assumed to be specified in
-feet unless followed by the letter \fIm\fP or the word \fImeters\fP in
-either upper or lower case.  Latitude and longitude information may be
-expressed in either decimal format (74.6864) or degree, minute, second
-(DMS) format (74 41 11.0).
+antenna height, interpreted by default as  above ground level (AGL),
+each separated by a single line-feed character.  The antenna height is
+assumed to be specified in feet unless followed by the letter \fIm\fP or
+the word \fImeters\fP in either upper or lower case.  You can optionally
+add a single line following the altitude containing either \fMSL\f or
+\fAGL\f to indicate that the altitude is measured from sea level or ground
+level.  Latitude and longitude information may be expressed in either
+decimal format (74.6864) or degree, minute, second (DMS) format (74 41 11.0).
 .PP
 For example, a site location file describing television station WNJT-DT,
 Trenton, NJ (\fIwnjt-dt.qth\fP) might read as follows:
@@ -461,6 +465,8 @@ line will return a summary of \fBSPLAT!\fP's command line options:
  -gpsav preserve gnuplot temporary working files after SPLAT! execution
 .br
 -imperial employ imperial rather than metric units for all user I/O
+.br
+-msl assume TX and RX site altitudes are referenced from MSL instead of AGL
 .br
 -olditm invoke older ITM propagation model rather than the newer ITWOM
 .br

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,7 @@ int main(int argc, const char *argv[]) {
     sr.command_line_log = false;
     sr.rxsite = false;
     sr.metric = true;
+    sr.msl = false;
     sr.dbm = false;
     sr.bottom_legend = true;
     sr.smooth_contours = false;
@@ -183,6 +184,7 @@ int main(int argc, const char *argv[]) {
                "Longley-Rice\n"
                "  -imperial employ imperial rather than metric units for all "
                "user I/O\n"
+               "  -msl use MSL for TX/RX altitudes instead of AGL\n"
                "-maxpages ["
             << sr.maxpages
             << "] Maximum Analysis Region capability: 1, 4, 9, 16, 25, 36, 49, "
@@ -396,6 +398,9 @@ int main(int argc, const char *argv[]) {
 
         if (strcmp(argv[x], "-imperial") == 0)
             sr.metric = false;
+
+        if (strcmp(argv[x], "-msl") == 0)
+            sr.msl = true;
 
         if (strcmp(argv[x], "-gpsav") == 0)
             sr.gpsav = true;
@@ -618,6 +623,14 @@ int main(int argc, const char *argv[]) {
             fprintf(stderr, "\n%c*** ERROR: No receiver site found or specified!\n\n", 7);
             exit(-1);
         }
+    }
+
+    /* Adjust TX/RX for MSL */
+    if (sr.msl) {
+        for (x = 0; x < tx_site.size(); x++) {
+            tx_site[x].amsl_flag = true;
+        }
+        rx_site.amsl_flag = true;
     }
     
     /* check if the output map should have a bottom legend */

--- a/src/site.cpp
+++ b/src/site.cpp
@@ -16,7 +16,7 @@
 
 using namespace std;
 
-Site::Site() {}
+Site::Site() { amsl_flag = false; }
 
 Site::Site(const string &filename) { LoadQTH(filename); }
 
@@ -143,7 +143,6 @@ void Site::LoadQTH(const string &filename) {
 
     /* Antenna Height */
     fgets(string, 49, fd);
-    fclose(fd);
 
     /* Remove <CR> and/or <LF> from antenna height string */
     for (x = 0; string[x] != 13 && string[x] != 10 && string[x] != 0; x++)
@@ -172,5 +171,16 @@ void Site::LoadQTH(const string &filename) {
         sscanf(string, "%f", &alt);
     }
 
+    /* Whether height is MSL or AGL */
+    amsl_flag = false;
+    if (!feof(fd)) {
+        fgets(string, 49, fd);
+	if (string[0] == 'M' || string[0] == 'm') {
+	    amsl_flag = true;
+	}
+    }
+
+    fclose(fd);
+    
     this->filename = qthfile;
 }

--- a/src/site.h
+++ b/src/site.h
@@ -21,7 +21,7 @@ class Site {
     double lat;
     double lon;
     float alt;
-    unsigned char amsl_flag;
+    bool amsl_flag;
     std::string name;
     std::string filename;
 

--- a/src/splat_run.h
+++ b/src/splat_run.h
@@ -95,6 +95,7 @@ class SplatRun {
     bool rxsite;
 
     bool metric;
+    bool msl;
     bool dbm;
     bool smooth_contours;
     bool bottom_legend;


### PR DESCRIPTION
Adds another (optional) field to site files to specify MSL or AGL and a command-line switch "-msl" which enables that for all sites even if not specified in their individual QTH files.

Fixes #43 