### PR TITLE
BREAKING CHANGE: Default to standard longitude values for TX and RX sites

### DIFF
--- a/docs/english/splat.man
+++ b/docs/english/splat.man
@@ -71,6 +71,8 @@ splat
 [-imperial]
 .br
 [-olditm]
+.br
+[-oldlon]
 .SH DESCRIPTION
 \fBSPLAT!\fP is a powerful terrestrial RF propagation and terrain
 analysis tool for the spectrum between 20 MHz and 20 GHz.
@@ -200,7 +202,7 @@ Trenton, NJ (\fIwnjt-dt.qth\fP) might read as follows:
 .br
         40.2828
 .br
-        74.6864
+        -74.6864
 .br
         990.00
 \fR
@@ -463,6 +465,8 @@ line will return a summary of \fBSPLAT!\fP's command line options:
 -imperial employ imperial rather than metric units for all user I/O
 .br
 -olditm invoke older ITM propagation model rather than the newer ITWOM
+.br
+-oldlon use old-style longitude (west is negative) for TX and RX sites
 .br
 \fR
 The command-line options for \fCsplat\fR and \fCsplat-hd\fR are identical.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,7 @@ int main(int argc, const char *argv[]) {
     sr.command_line_log = false;
     sr.rxsite = false;
     sr.metric = true;
+    sr.old_longitude = false;
     sr.dbm = false;
     sr.bottom_legend = true;
     sr.smooth_contours = false;
@@ -181,6 +182,8 @@ int main(int argc, const char *argv[]) {
                "SPLAT! execution\n"
                "   -itwom invoke the ITWOM model instead of using "
                "Longley-Rice\n"
+               "  -oldlon use old-style longitude (west is negative) instead "
+               "of the default GPS-compatible longitude for TX and RX sites\n"
                "  -imperial employ imperial rather than metric units for all "
                "user I/O\n"
                "-maxpages ["
@@ -402,6 +405,9 @@ int main(int argc, const char *argv[]) {
 
         if (strcmp(argv[x], "-geo") == 0)
             sr.geo = true;
+
+        if (strcmp(argv[x], "-oldlon") == 0)
+            sr.old_longitude = true;
 
         if (strcmp(argv[x], "-kml") == 0)
             sr.kml = true;
@@ -628,6 +634,14 @@ int main(int argc, const char *argv[]) {
 		sr.bottom_legend = true;
 	}
 
+    /* Flip longitude if needed - internally we use flipped longitude */
+    if (!sr.old_longitude) {
+        for (x = 0; x < tx_site.size(); x++) {
+	    tx_site[x].lon = -tx_site[x].lon;
+        }
+	rx_site.lon = -rx_site.lon;
+    }
+    
     switch (sr.maxpages) {
     case 1:
         if (!sr.hd_mode) {

--- a/src/splat_run.h
+++ b/src/splat_run.h
@@ -95,6 +95,7 @@ class SplatRun {
     bool rxsite;
 
     bool metric;
+    bool old_longitude;
     bool dbm;
     bool smooth_contours;
     bool bottom_legend;


### PR DESCRIPTION
Changes the default when reading longitude for TX and RX sites to use standard west-is-negative coordinate values.  Also adds a new flag `-oldlon` to keep things the way they were, for compatibility with existing files.  Does not change the way longitude is used internally (which would be a vastly more extensive change), but at least makes the public interface a little more consistent with modern expectations.

Fixes #31