### PR TITLE
Update macOS runners in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
   # macOS Intel builds
   macos-intel:
     name: macOS Intel (${{ matrix.build_type }})
-    runs-on: macos-13  # Intel runner
+    runs-on: macos-15-intel  # Intel runner
     strategy:
       fail-fast: false
       matrix:
@@ -108,7 +108,7 @@ jobs:
   # macOS ARM (Apple Silicon) builds
   macos-arm:
     name: macOS ARM (${{ matrix.build_type }})
-    runs-on: macos-14  # ARM (M1) runner
+    runs-on: macos-latest  # ARM runner
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update CI to use macOS Intel `macos-15-intel` and macOS ARM `macos-latest` runners.
> 
> - **CI (GitHub Actions)**:
>   - Update macOS Intel runner to `macos-15-intel` in `.github/workflows/ci.yml`.
>   - Update macOS ARM runner to `macos-latest` in `.github/workflows/ci.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25220b581f3efd4103e3cd5bee623159e8d9220c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->