### PR TITLE
Add command line switch tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SPLAT_SOURCES
     src/antenna_pattern.cpp
     src/boundary_file.cpp
     src/city_file.cpp
+    src/command_line_parser.cpp
     src/dem.cpp
     src/elevation_map.cpp
     src/gnuplot.cpp
@@ -153,6 +154,7 @@ FetchContent_MakeAvailable(googletest)
 # Explicitly list test source files
 set(TEST_SOURCES
     tests/antenna_pattern_test.cpp
+    tests/command_line_parser_test.cpp
     tests/image_output_test.cpp
     tests/input_file_parsing_test.cpp
     tests/itwom_test.cpp
@@ -172,6 +174,7 @@ set(TEST_REQUIRED_SOURCES
     src/antenna_pattern.cpp
     src/boundary_file.cpp
     src/city_file.cpp
+    src/command_line_parser.cpp
     src/dem.cpp
     src/elevation_map.cpp
     src/gnuplot.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(splat
     antenna_pattern.cpp
     boundary_file.cpp
     city_file.cpp
+    command_line_parser.cpp
     dem.cpp
     elevation_map.cpp
     gnuplot.cpp

--- a/src/command_line_parser.cpp
+++ b/src/command_line_parser.cpp
@@ -1,0 +1,540 @@
+/** @file command_line_parser.cpp
+ *
+ * Command-line argument parser for SPLAT!
+ * 
+ * @copyright 1997 - 2018 John A. Magliacane (KD2BD) and contributors.
+ * See revision control history for contributions.
+ * This file is covered by the LICENSE.md file in the root of this project.
+ */
+
+#include "command_line_parser.h"
+#include "splat_run.h"
+#include <cstring>
+#include <iostream>
+
+void PrintHelp(const SplatRun &sr) {
+    std::cout
+        << "\n\t\t --==[ " << SplatRun::splat_name << " v"
+        << SplatRun::splat_version
+        << " Available Options... ]==--\n\n"
+           "       -t txsite(s).qth\n"
+           "       -r sr.rxsite.qth\n"
+           "       -c plot LOS coverage of TX(s) with an RX antenna at X "
+           "feet/meters AGL\n"
+           "       -L plot path loss map of TX based on an RX at X "
+           "feet/meters AGL\n"
+           "       -s filename(s) of city/site file(s) to import (5 max)\n"
+           "       -b filename(s) of cartographic boundary file(s) to "
+           "import (5 max)\n"
+           "       -p filename of terrain profile graph to plot\n"
+           "       -e filename of terrain elevation graph to plot\n"
+           "       -h filename of terrain height graph to plot\n"
+           "       -H filename of normalized terrain height graph to plot\n"
+           "       -l filename of path loss graph to plot\n"
+           "       -o filename of topographic map to generate (without "
+           "suffix)\n"
+           "       -d sdf file directory path (overrides path in "
+           "~/.splat_path file)\n"
+           "       -m earth radius multiplier\n"
+           "       -n do not plot LOS paths in maps\n"
+           "       -N do not produce unnecessary site or obstruction "
+           "reports\n"
+           "       -f frequency for Fresnel zone calculation (MHz)\n"
+           "       -R modify default range for -c or -L "
+           "(miles/kilometers)\n"
+           "       -v N verbosity level. Default is 1. Set to 0 to quiet "
+           "everything.\n"
+           "      -st use a single CPU thread (classic mode)\n"
+           "      -hd Use High Definition mode (3600 ppd vs 1200 ppd). "
+           "Requires SRTM-1 SDF files.\n"
+           "      -sc display smooth rather than quantized contour levels\n"
+           "      -db threshold beyond which contours will not be "
+           "displayed\n"
+           "      -nf do not plot Fresnel zones in height plots\n"
+           "      -fz Fresnel zone clearance percentage (default = 60)\n"
+           "      -gc ground clutter height (feet/meters)\n"
+           "     -jpg when generating maps, create jpgs instead of pngs or "
+           "ppms\n"
+#ifdef HAVE_LIBPNG
+           "     -ppm when generating maps, create ppms instead of pngs or "
+           "jpgs\n"
+#endif
+           "     -tif create geotiff instead of png or jpeg\n"
+           "     -ngs display greyscale topography as white in images\n"
+           "     -erp override ERP in .lrp file (Watts)\n"
+           "     -ano name of alphanumeric output file\n"
+           "     -ani name of alphanumeric input file\n"
+           "     -udt name of user defined terrain input file\n"
+           "     -kml generate Google Earth (.kml) compatible output\n"
+           "     -kmz generate Google Earth compressed (.kmz) output\n"
+           "     -geo generate an Xastir .geo georeference file (with "
+           "image output)\n"
+           "     -dbm plot signal power level contours rather than field "
+           "strength\n"
+           "     -log copy command line std::string to this output file\n"
+           "     -json create JSON file containing configuration \n"
+           "   -gpsav preserve gnuplot temporary working files after "
+           "SPLAT! execution\n"
+           "   -itwom invoke the ITWOM model instead of using "
+           "Longley-Rice\n"
+           "  -imperial employ imperial rather than metric units for all "
+           "user I/O\n"
+           "  -msl use MSL for TX/RX altitudes instead of AGL\n"
+           "-maxpages ["
+        << sr.maxpages
+        << "] Maximum Analysis Region capability: 1, 4, 9, 16, 25, 36, 49, "
+           "64 \n"
+           "  -sdelim ["
+        << sr.sdf_delimiter
+        << "] Lat and lon delimeter in SDF filenames \n"
+           "\n"
+           "See the documentation for more details.\n\n";
+}
+
+bool ParseCommandLine(int argc, const char *argv[], SplatRun &sr,
+                      CommandLineOptions &options) {
+    // Check for help or no arguments
+    if (argc == 1 || (argc == 2 && strcmp(argv[1], "--help") == 0)) {
+        options.show_help = true;
+        PrintHelp(sr);
+        return false;
+    }
+
+    size_t x, y, z = 0;
+
+    /* Scan for command line arguments */
+    y = argc - 1;
+
+    for (x = 1; x <= y; x++) {
+        if (strcmp(argv[x], "-R") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                sscanf(argv[z], "%lf", &sr.max_range);
+
+                if (sr.max_range < 0.0)
+                    sr.max_range = 0.0;
+
+                if (sr.max_range > 1000.0)
+                    sr.max_range = 1000.0;
+            }
+        }
+
+        if (strcmp(argv[x], "-m") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                sscanf(argv[z], "%lf", &sr.er_mult);
+
+                if (sr.er_mult < 0.1)
+                    sr.er_mult = 1.0;
+
+                if (sr.er_mult > 1.0e6)
+                    sr.er_mult = 1.0e6;
+
+                sr.earthradius *= sr.er_mult;
+            }
+        }
+
+        if (strcmp(argv[x], "-v") == 0) {
+            z = x + 1;
+
+            if (z < (size_t)argc && argv[z][0] && argv[z][0] != '-') {
+                int verbose;
+                sscanf(argv[z], "%d", &verbose);
+                sr.verbose = verbose != 0;
+            }
+        }
+
+        if (strcmp(argv[x], "-gc") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                sscanf(argv[z], "%lf", &sr.clutter);
+
+                if (sr.clutter < 0.0)
+                    sr.clutter = 0.0;
+            }
+        }
+
+        if (strcmp(argv[x], "-fz") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                sscanf(argv[z], "%lf", &sr.fzone_clearance);
+
+                if (sr.fzone_clearance < 0.0 || sr.fzone_clearance > 100.0)
+                    sr.fzone_clearance = 60.0;
+
+                sr.fzone_clearance /= 100.0;
+            }
+        }
+
+        if (strcmp(argv[x], "-o") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-')
+                options.mapfile = argv[z];
+            sr.map = true;
+        }
+
+        if (strcmp(argv[x], "-log") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-')
+                options.logfile = argv[z];
+
+            sr.command_line_log = true;
+        }
+
+        if (strcmp(argv[x], "-udt") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-')
+                options.udt_file = argv[z];
+        }
+
+        if (strcmp(argv[x], "-c") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                sscanf(argv[z], "%lf", &sr.altitude);
+                sr.map = true;
+                sr.coverage = true;
+                sr.area_mode = true;
+            }
+        }
+
+        if (strcmp(argv[x], "-db") == 0 || strcmp(argv[x], "-dB") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0]) /* A minus argument is legal here */
+                sscanf(argv[z], "%d", &sr.contour_threshold);
+        }
+
+        if (strcmp(argv[x], "-p") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                options.terrain_file = argv[z];
+                sr.terrain_plot = true;
+                sr.pt2pt_mode = true;
+            }
+        }
+
+        if (strcmp(argv[x], "-e") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                options.elevation_file = argv[z];
+                sr.elevation_plot = true;
+                sr.pt2pt_mode = true;
+            }
+        }
+
+        if (strcmp(argv[x], "-h") == 0 || strcmp(argv[x], "-H") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                options.height_file = argv[z];
+                sr.height_plot = true;
+                sr.pt2pt_mode = true;
+            }
+
+            sr.norm = strcmp(argv[x], "-H") == 0 ? true : false;
+        }
+
+        bool imagetype_set = false;
+#ifdef HAVE_LIBPNG
+        if (strcmp(argv[x], "-ppm") == 0) {
+            if (imagetype_set && sr.imagetype != IMAGETYPE_PPM) {
+                fprintf(stdout,
+                        "-jpg and -ppm are exclusive options, ignoring -ppm.\n");
+            } else {
+                sr.imagetype = IMAGETYPE_PPM;
+                imagetype_set = true;
+            }
+        }
+#endif
+#ifdef HAVE_LIBGDAL
+        if (strcmp(argv[x], "-tif") == 0) {
+            if (imagetype_set && sr.imagetype != IMAGETYPE_PPM) {
+                fprintf(stdout,
+                        "-tif and -ppm are exclusive options, ignoring -ppm.\n");
+            } else {
+                sr.imagetype = IMAGETYPE_GEOTIFF;
+                imagetype_set = true;
+            }
+        }
+#endif
+#ifdef HAVE_LIBJPEG
+        if (strcmp(argv[x], "-jpg") == 0) {
+            if (imagetype_set && sr.imagetype != IMAGETYPE_JPG) {
+#ifdef HAVE_LIBPNG
+                fprintf(stdout,
+                        "-jpg and -ppm are exclusive options, ignoring -jpg.\n");
+#else
+                fprintf(stdout,
+                        "-jpg and -png are exclusive options, ignoring -jpg.\n");
+#endif
+            } else {
+                sr.imagetype = IMAGETYPE_JPG;
+                imagetype_set = true;
+            }
+        }
+#endif
+
+#ifdef HAVE_LIBGDAL
+        if (strcmp(argv[x], "-proj") == 0) {
+            if (sr.imagetype == IMAGETYPE_GEOTIFF ||
+                sr.imagetype == IMAGETYPE_PNG || sr.imagetype == IMAGETYPE_JPG) {
+                z = x + 1;
+                if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                    if (strcmp(argv[z], "epsg:3857") == 0) {
+                        sr.projection = PROJ_EPSG_3857;
+                    } else if (strcmp(argv[z], "epsg:4326") == 0) {
+                        sr.projection = PROJ_EPSG_4326;
+                    } else {
+                        std::cerr << "Ignoring unknown projection " << argv[z]
+                                  << " and taking epsg:4326 instead.\n";
+                    }
+                }
+            } else {
+                std::cerr << "-proj supports only gdal output formats. Please "
+                             "use -png, -tif or -jpg.\n";
+            }
+        }
+#endif
+
+        if (strcmp(argv[x], "-imperial") == 0)
+            sr.metric = false;
+
+        if (strcmp(argv[x], "-msl") == 0)
+            sr.msl = true;
+
+        if (strcmp(argv[x], "-gpsav") == 0)
+            sr.gpsav = true;
+
+        if (strcmp(argv[x], "-geo") == 0)
+            sr.geo = true;
+
+        if (strcmp(argv[x], "-kml") == 0)
+            sr.kml = true;
+
+        if (strcmp(argv[x], "-kmz") == 0)
+            sr.kmz = true;
+
+        if (strcmp(argv[x], "-json") == 0)
+            sr.json = true;
+
+        if (strcmp(argv[x], "-nf") == 0)
+            sr.fresnel_plot = false;
+
+        if (strcmp(argv[x], "-ngs") == 0)
+            sr.ngs = true;
+
+        if (strcmp(argv[x], "-n") == 0)
+            sr.nolospath = true;
+
+        if (strcmp(argv[x], "-dbm") == 0)
+            sr.dbm = true;
+
+        if (strcmp(argv[x], "-sc") == 0)
+            sr.smooth_contours = true;
+
+        if (strcmp(argv[x], "-st") == 0)
+            sr.multithread = false;
+
+        if (strcmp(argv[x], "-itwom") == 0)
+            sr.propagation_model = PROP_ITWOM;
+
+        if (strcmp(argv[x], "-N") == 0) {
+            sr.nolospath = true;
+            sr.nositereports = true;
+        }
+
+        if (strcmp(argv[x], "-d") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-')
+                sr.sdf_path = argv[z];
+        }
+
+        if (strcmp(argv[x], "-t") == 0) {
+            /* Read Transmitter Location */
+
+            z = x + 1;
+
+            while (z <= y && argv[z][0] && argv[z][0] != '-' &&
+                   options.tx_site_files.size() < 30) {
+                options.tx_site_files.push_back(argv[z]);
+                z++;
+            }
+
+            z--;
+        }
+
+        if (strcmp(argv[x], "-L") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                sscanf(argv[z], "%lf", &sr.altitudeLR);
+                sr.map = true;
+                sr.LRmap = true;
+                sr.area_mode = true;
+
+                if (sr.coverage)
+                    fprintf(stdout,
+                            "c and L are exclusive options, ignoring L.\n");
+            }
+        }
+
+        if (strcmp(argv[x], "-l") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                options.longley_file = argv[z];
+                sr.longley_plot = true;
+                sr.pt2pt_mode = true;
+            }
+        }
+
+        if (strcmp(argv[x], "-r") == 0) {
+            /* Read Receiver Location */
+
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                options.rx_site_file = argv[z];
+                sr.rxsite = true;
+                sr.pt2pt_mode = true;
+            }
+        }
+
+        if (strcmp(argv[x], "-s") == 0) {
+            /* Read city file(s) */
+
+            z = x + 1;
+
+            while (z <= y && argv[z][0] && argv[z][0] != '-') {
+                options.city_files.push_back(argv[z]);
+                z++;
+            }
+
+            z--;
+        }
+
+        if (strcmp(argv[x], "-b") == 0) {
+            /* Read Boundary File(s) */
+
+            z = x + 1;
+
+            while (z <= y && argv[z][0] && argv[z][0] != '-') {
+                options.boundary_files.push_back(argv[z]);
+                z++;
+            }
+
+            z--;
+        }
+
+        if (strcmp(argv[x], "-f") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                sscanf(argv[z], "%lf", &(sr.forced_freq));
+
+                if (sr.forced_freq < 20.0)
+                    sr.forced_freq = 0.0;
+
+                if (sr.forced_freq > 20.0e3)
+                    sr.forced_freq = 20.0e3;
+            }
+        }
+
+        if (strcmp(argv[x], "-erp") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                sscanf(argv[z], "%lf", &(sr.forced_erp));
+
+                if (sr.forced_erp < 0.0)
+                    sr.forced_erp = -1.0;
+            }
+        }
+
+        if (strcmp(argv[x], "-ano") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-')
+                options.ano_filename = argv[z];
+        }
+
+        if (strcmp(argv[x], "-ani") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-')
+                options.ani_filename = argv[z];
+        }
+
+        if (strcmp(argv[x], "-maxpages") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                std::string maxpages_str = argv[z];
+                if (sscanf(maxpages_str.c_str(), "%d", &sr.maxpages) != 1) {
+                    options.parse_error = true;
+                    options.error_message =
+                        "Could not parse maxpages: " + maxpages_str;
+                    return false;
+                }
+            }
+        }
+
+        if (strcmp(argv[x], "-sdelim") == 0) {
+            z = x + 1;
+
+            if (z <= y && argv[z][0] && argv[z][0] != '-') {
+                sr.sdf_delimiter = argv[z];
+            }
+        }
+
+        if (strcmp(argv[x], "-hd") == 0) {
+            sr.hd_mode = true;
+        }
+    } /* end of command line argument scanning */
+
+    return true;
+}
+
+bool ValidateCommandLine(const SplatRun &sr, const CommandLineOptions &options) {
+    // Check for transmitter sites
+    if (options.tx_site_files.empty()) {
+        std::cerr << "\n*** ERROR: No transmitter site(s) specified!\n\n";
+        return false;
+    }
+
+    // Validate maxpages
+    switch (sr.maxpages) {
+    case 1:
+        if (!sr.hd_mode) {
+            std::cerr
+                << "\n*** ERROR: -maxpages must be >= 4 if not in HD mode!\n\n";
+            return false;
+        }
+        break;
+    case 4:
+    case 9:
+    case 16:
+    case 25:
+    case 36:
+    case 49:
+    case 64:
+        break;
+    default:
+        std::cerr << "\n*** ERROR: -maxpages must be one of 1, 4, 9, 16, 25, 36, "
+                     "49, 64\n\n";
+        return false;
+    }
+
+    return true;
+}

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -1,0 +1,73 @@
+/** @file command_line_parser.h
+ *
+ * Command-line argument parser for SPLAT!
+ * Extracts and validates command-line arguments into SplatRun configuration
+ * 
+ * @copyright 1997 - 2018 John A. Magliacane (KD2BD) and contributors.
+ * See revision control history for contributions.
+ * This file is covered by the LICENSE.md file in the root of this project.
+ */
+
+#ifndef COMMAND_LINE_PARSER_H
+#define COMMAND_LINE_PARSER_H
+
+#include "splat_run.h"
+#include "site.h"
+#include <string>
+#include <vector>
+
+/**
+ * Structure to hold parsed command-line options
+ */
+struct CommandLineOptions {
+    // File paths
+    std::vector<std::string> tx_site_files;
+    std::string rx_site_file;
+    std::vector<std::string> city_files;
+    std::vector<std::string> boundary_files;
+    std::string mapfile;
+    std::string elevation_file;
+    std::string height_file;
+    std::string longley_file;
+    std::string terrain_file;
+    std::string udt_file;
+    std::string ani_filename;
+    std::string ano_filename;
+    std::string logfile;
+    
+    // SplatRun configuration (will be populated into sr)
+    // Most settings will be set directly in sr parameter
+    
+    // Parse status
+    bool show_help = false;
+    bool parse_error = false;
+    std::string error_message;
+};
+
+/**
+ * Parse command-line arguments and populate SplatRun configuration
+ * 
+ * @param argc Number of command-line arguments
+ * @param argv Array of command-line argument strings
+ * @param sr SplatRun object to populate with parsed settings
+ * @param options CommandLineOptions structure to populate with file paths
+ * @return true if parsing was successful, false if error or help requested
+ */
+bool ParseCommandLine(int argc, const char *argv[], SplatRun &sr,
+                      CommandLineOptions &options);
+
+/**
+ * Validate parsed command-line options for consistency
+ * 
+ * @param sr SplatRun configuration
+ * @param options Parsed command-line options
+ * @return true if validation passed, false otherwise
+ */
+bool ValidateCommandLine(const SplatRun &sr, const CommandLineOptions &options);
+
+/**
+ * Print help message showing available command-line options
+ */
+void PrintHelp(const SplatRun &sr);
+
+#endif // COMMAND_LINE_PARSER_H

--- a/tests/command_line_parser_test.cpp
+++ b/tests/command_line_parser_test.cpp
@@ -1,0 +1,877 @@
+/** @file command_line_parser_test.cpp
+ *
+ * Unit tests for command-line argument parser
+ * 
+ * @copyright 1997 - 2018 John A. Magliacane (KD2BD) and contributors.
+ */
+
+#include "../src/command_line_parser.h"
+#include "../src/splat_run.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+// Helper function to create argv array from vector of strings
+std::vector<const char *> MakeArgv(const std::vector<std::string> &args) {
+    std::vector<const char *> argv;
+    for (const auto &arg : args) {
+        argv.push_back(arg.c_str());
+    }
+    return argv;
+}
+
+// Test fixture for command-line parser
+class CommandLineParserTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        // Initialize SplatRun with defaults
+        sr.maxpages = 16;
+        sr.arraysize = -1;
+        sr.propagation_model = PROP_ITM;
+        sr.hd_mode = false;
+        sr.coverage = false;
+        sr.LRmap = false;
+        sr.terrain_plot = false;
+        sr.elevation_plot = false;
+        sr.height_plot = false;
+        sr.map = false;
+        sr.longley_plot = false;
+        sr.norm = false;
+        sr.topomap = false;
+        sr.geo = false;
+        sr.kml = false;
+        sr.json = false;
+        sr.pt2pt_mode = false;
+        sr.area_mode = false;
+        sr.ngs = false;
+        sr.nolospath = false;
+        sr.nositereports = false;
+        sr.fresnel_plot = true;
+        sr.command_line_log = false;
+        sr.rxsite = false;
+        sr.metric = true;
+        sr.msl = false;
+        sr.dbm = false;
+        sr.bottom_legend = true;
+        sr.smooth_contours = false;
+        sr.altitude = 0.0;
+        sr.altitudeLR = 0.0;
+        sr.tx_range = 0.0;
+        sr.rx_range = 0.0;
+        sr.deg_range = 0.0;
+        sr.deg_limit = 0.0;
+        sr.max_range = 0.0;
+        sr.clutter = 0.0;
+        sr.forced_erp = -1.0;
+        sr.forced_freq = 0.0;
+        sr.fzone_clearance = 0.6;
+        sr.contour_threshold = 0;
+        sr.rx_site.lat = 91.0;
+        sr.rx_site.lon = 361.0;
+        sr.earthradius = EARTHRADIUS;
+#ifdef HAVE_LIBPNG
+        sr.imagetype = IMAGETYPE_PNG;
+#else
+        sr.imagetype = IMAGETYPE_PPM;
+#endif
+        sr.projection = PROJ_EPSG_4326;
+        sr.multithread = true;
+        sr.verbose = 1;
+        sr.sdf_delimiter = "_";
+    }
+
+    SplatRun sr;
+    CommandLineOptions options;
+};
+
+// Test help flag
+TEST_F(CommandLineParserTest, ShowHelp) {
+    std::vector<std::string> args = {"splat", "--help"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_FALSE(result);
+    EXPECT_TRUE(options.show_help);
+}
+
+// Test no arguments
+TEST_F(CommandLineParserTest, NoArguments) {
+    std::vector<std::string> args = {"splat"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_FALSE(result);
+    EXPECT_TRUE(options.show_help);
+}
+
+// Test -t (transmitter site) flag
+TEST_F(CommandLineParserTest, TransmitterSingleSite) {
+    std::vector<std::string> args = {"splat", "-t", "tx1.qth"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    ASSERT_EQ(options.tx_site_files.size(), 1);
+    EXPECT_EQ(options.tx_site_files[0], "tx1.qth");
+}
+
+TEST_F(CommandLineParserTest, TransmitterMultipleSites) {
+    std::vector<std::string> args = {"splat", "-t", "tx1.qth", "tx2.qth",
+                                     "tx3.qth"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    ASSERT_EQ(options.tx_site_files.size(), 3);
+    EXPECT_EQ(options.tx_site_files[0], "tx1.qth");
+    EXPECT_EQ(options.tx_site_files[1], "tx2.qth");
+    EXPECT_EQ(options.tx_site_files[2], "tx3.qth");
+}
+
+// Test -r (receiver site) flag
+TEST_F(CommandLineParserTest, ReceiverSite) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-r", "rx.qth"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(options.rx_site_file, "rx.qth");
+    EXPECT_TRUE(sr.rxsite);
+    EXPECT_TRUE(sr.pt2pt_mode);
+}
+
+// Test -c (coverage) flag
+TEST_F(CommandLineParserTest, CoverageMode) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-c", "10.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.coverage);
+    EXPECT_TRUE(sr.map);
+    EXPECT_TRUE(sr.area_mode);
+    EXPECT_DOUBLE_EQ(sr.altitude, 10.0);
+}
+
+// Test -L (path loss map) flag
+TEST_F(CommandLineParserTest, PathLossMap) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-L", "25.5"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.LRmap);
+    EXPECT_TRUE(sr.map);
+    EXPECT_TRUE(sr.area_mode);
+    EXPECT_DOUBLE_EQ(sr.altitudeLR, 25.5);
+}
+
+// Test -s (city files) flag
+TEST_F(CommandLineParserTest, CityFiles) {
+    std::vector<std::string> args = {"splat", "-t",      "tx.qth", "-s",
+                                     "city1.dat", "city2.dat"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    ASSERT_EQ(options.city_files.size(), 2);
+    EXPECT_EQ(options.city_files[0], "city1.dat");
+    EXPECT_EQ(options.city_files[1], "city2.dat");
+}
+
+// Test -b (boundary files) flag
+TEST_F(CommandLineParserTest, BoundaryFiles) {
+    std::vector<std::string> args = {"splat", "-t",     "tx.qth",     "-b",
+                                     "bound1.dat", "bound2.dat", "bound3.dat"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    ASSERT_EQ(options.boundary_files.size(), 3);
+    EXPECT_EQ(options.boundary_files[0], "bound1.dat");
+    EXPECT_EQ(options.boundary_files[1], "bound2.dat");
+    EXPECT_EQ(options.boundary_files[2], "bound3.dat");
+}
+
+// Test -p (terrain profile) flag
+TEST_F(CommandLineParserTest, TerrainProfile) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-r", "rx.qth",
+                                     "-p",     "terrain.png"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(options.terrain_file, "terrain.png");
+    EXPECT_TRUE(sr.terrain_plot);
+    EXPECT_TRUE(sr.pt2pt_mode);
+}
+
+// Test -e (elevation plot) flag
+TEST_F(CommandLineParserTest, ElevationPlot) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-r", "rx.qth",
+                                     "-e",     "elevation.png"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(options.elevation_file, "elevation.png");
+    EXPECT_TRUE(sr.elevation_plot);
+    EXPECT_TRUE(sr.pt2pt_mode);
+}
+
+// Test -h (height plot) flag
+TEST_F(CommandLineParserTest, HeightPlot) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-r", "rx.qth",
+                                     "-h",     "height.png"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(options.height_file, "height.png");
+    EXPECT_TRUE(sr.height_plot);
+    EXPECT_TRUE(sr.pt2pt_mode);
+    EXPECT_FALSE(sr.norm);
+}
+
+// Test -H (normalized height plot) flag
+TEST_F(CommandLineParserTest, NormalizedHeightPlot) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-r", "rx.qth",
+                                     "-H",     "height_norm.png"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(options.height_file, "height_norm.png");
+    EXPECT_TRUE(sr.height_plot);
+    EXPECT_TRUE(sr.pt2pt_mode);
+    EXPECT_TRUE(sr.norm);
+}
+
+// Test -l (longley plot) flag
+TEST_F(CommandLineParserTest, LongleyPlot) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-r", "rx.qth",
+                                     "-l",     "longley.png"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(options.longley_file, "longley.png");
+    EXPECT_TRUE(sr.longley_plot);
+    EXPECT_TRUE(sr.pt2pt_mode);
+}
+
+// Test -o (output map) flag
+TEST_F(CommandLineParserTest, OutputMap) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-o", "output"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(options.mapfile, "output");
+    EXPECT_TRUE(sr.map);
+}
+
+// Test -d (SDF directory) flag
+TEST_F(CommandLineParserTest, SDFDirectory) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-d",
+                                     "/path/to/sdf"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(sr.sdf_path, "/path/to/sdf");
+}
+
+// Test -m (earth radius multiplier) flag
+TEST_F(CommandLineParserTest, EarthRadiusMultiplier) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-m", "1.333"};
+    auto argv = MakeArgv(args);
+
+    double original_radius = sr.earthradius;
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.er_mult, 1.333);
+    EXPECT_DOUBLE_EQ(sr.earthradius, original_radius * 1.333);
+}
+
+TEST_F(CommandLineParserTest, EarthRadiusMultiplierTooSmall) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-m", "0.05"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.er_mult, 1.0); // Should be clamped to 1.0
+}
+
+TEST_F(CommandLineParserTest, EarthRadiusMultiplierTooLarge) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-m", "2000000.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.er_mult, 1.0e6); // Should be clamped to 1e6
+}
+
+// Test -n (no LOS path) flag
+TEST_F(CommandLineParserTest, NoLOSPath) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-n"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.nolospath);
+}
+
+// Test -N (no site reports) flag
+TEST_F(CommandLineParserTest, NoSiteReports) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-N"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.nolospath);
+    EXPECT_TRUE(sr.nositereports);
+}
+
+// Test -f (frequency) flag
+TEST_F(CommandLineParserTest, Frequency) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-f", "915.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.forced_freq, 915.0);
+}
+
+TEST_F(CommandLineParserTest, FrequencyTooLow) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-f", "10.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.forced_freq, 0.0); // Should be set to 0
+}
+
+TEST_F(CommandLineParserTest, FrequencyTooHigh) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-f", "25000.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.forced_freq, 20.0e3); // Should be clamped to 20000
+}
+
+// Test -R (range) flag
+TEST_F(CommandLineParserTest, Range) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-R", "50.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.max_range, 50.0);
+}
+
+TEST_F(CommandLineParserTest, RangeNegative) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-R", "-10.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.max_range, 0.0); // Should be clamped to 0
+}
+
+TEST_F(CommandLineParserTest, RangeTooLarge) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-R", "1500.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.max_range, 1000.0); // Should be clamped to 1000
+}
+
+// Test -v (verbosity) flag
+TEST_F(CommandLineParserTest, Verbosity) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-v", "0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(sr.verbose, 0);
+}
+
+// Test -st (single thread) flag
+TEST_F(CommandLineParserTest, SingleThread) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-st"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(sr.multithread);
+}
+
+// Test -hd (high definition) flag
+TEST_F(CommandLineParserTest, HighDefinition) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-hd"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.hd_mode);
+}
+
+// Test -sc (smooth contours) flag
+TEST_F(CommandLineParserTest, SmoothContours) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-sc"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.smooth_contours);
+}
+
+// Test -db (contour threshold) flag
+TEST_F(CommandLineParserTest, ContourThreshold) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-db", "-100"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(sr.contour_threshold, -100);
+}
+
+TEST_F(CommandLineParserTest, ContourThresholdAlternateCase) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-dB", "-90"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(sr.contour_threshold, -90);
+}
+
+// Test -nf (no fresnel) flag
+TEST_F(CommandLineParserTest, NoFresnel) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-nf"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(sr.fresnel_plot);
+}
+
+// Test -fz (fresnel zone clearance) flag
+TEST_F(CommandLineParserTest, FresnelZoneClearance) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-fz", "80"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.fzone_clearance, 0.8); // 80% -> 0.8
+}
+
+TEST_F(CommandLineParserTest, FresnelZoneClearanceNegative) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-fz", "-10"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.fzone_clearance, 0.6); // Should default to 60%
+}
+
+TEST_F(CommandLineParserTest, FresnelZoneClearanceTooLarge) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-fz", "150"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.fzone_clearance, 0.6); // Should default to 60%
+}
+
+// Test -gc (ground clutter) flag
+TEST_F(CommandLineParserTest, GroundClutter) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-gc", "30.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.clutter, 30.0);
+}
+
+TEST_F(CommandLineParserTest, GroundClutterNegative) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-gc", "-5.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.clutter, 0.0); // Should be clamped to 0
+}
+
+// Test image format flags
+#ifdef HAVE_LIBPNG
+TEST_F(CommandLineParserTest, PPMFormat) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-ppm"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(sr.imagetype, IMAGETYPE_PPM);
+}
+#endif
+
+#ifdef HAVE_LIBJPEG
+TEST_F(CommandLineParserTest, JPGFormat) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-jpg"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(sr.imagetype, IMAGETYPE_JPG);
+}
+#endif
+
+#ifdef HAVE_LIBGDAL
+TEST_F(CommandLineParserTest, TIFFormat) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-tif"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(sr.imagetype, IMAGETYPE_GEOTIFF);
+}
+#endif
+
+// Test -ngs (no greyscale) flag
+TEST_F(CommandLineParserTest, NoGreyscale) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-ngs"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.ngs);
+}
+
+// Test -erp (effective radiated power) flag
+TEST_F(CommandLineParserTest, ERP) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-erp", "1000.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.forced_erp, 1000.0);
+}
+
+TEST_F(CommandLineParserTest, ERPNegative) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-erp", "-10.0"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_DOUBLE_EQ(sr.forced_erp, -1.0); // Should be set to -1
+}
+
+// Test -ano (alphanumeric output) flag
+TEST_F(CommandLineParserTest, AlphanumericOutput) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-ano",
+                                     "output.txt"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(options.ano_filename, "output.txt");
+}
+
+// Test -ani (alphanumeric input) flag
+TEST_F(CommandLineParserTest, AlphanumericInput) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-ani",
+                                     "input.txt"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(options.ani_filename, "input.txt");
+}
+
+// Test -udt (user defined terrain) flag
+TEST_F(CommandLineParserTest, UserDefinedTerrain) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-udt",
+                                     "terrain.udt"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(options.udt_file, "terrain.udt");
+}
+
+// Test -kml flag
+TEST_F(CommandLineParserTest, KMLOutput) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-kml"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.kml);
+}
+
+// Test -kmz flag
+TEST_F(CommandLineParserTest, KMZOutput) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-kmz"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.kmz);
+}
+
+// Test -geo flag
+TEST_F(CommandLineParserTest, GeoOutput) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-geo"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.geo);
+}
+
+// Test -dbm flag
+TEST_F(CommandLineParserTest, DBMOutput) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-dbm"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.dbm);
+}
+
+// Test -log flag
+TEST_F(CommandLineParserTest, LogOutput) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-log",
+                                     "command.log"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.command_line_log);
+    EXPECT_EQ(options.logfile, "command.log");
+}
+
+// Test -json flag
+TEST_F(CommandLineParserTest, JSONOutput) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-json"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.json);
+}
+
+// Test -gpsav flag
+TEST_F(CommandLineParserTest, GnuplotSave) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-gpsav"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.gpsav);
+}
+
+// Test -itwom flag
+TEST_F(CommandLineParserTest, ITWOMModel) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-itwom"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(sr.propagation_model, PROP_ITWOM);
+}
+
+// Test -imperial flag
+TEST_F(CommandLineParserTest, ImperialUnits) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-imperial"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(sr.metric);
+}
+
+// Test -msl flag
+TEST_F(CommandLineParserTest, MSLAltitude) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-msl"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.msl);
+}
+
+// Test -maxpages flag
+TEST_F(CommandLineParserTest, MaxPages) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-maxpages", "25"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(sr.maxpages, 25);
+}
+
+TEST_F(CommandLineParserTest, MaxPagesInvalid) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-maxpages",
+                                     "invalid"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_FALSE(result);
+    EXPECT_TRUE(options.parse_error);
+}
+
+// Test -sdelim flag
+TEST_F(CommandLineParserTest, SDFDelimiter) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-sdelim", ":"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(sr.sdf_delimiter, ":");
+}
+
+// Test validation - no transmitter sites
+TEST_F(CommandLineParserTest, ValidateNoTransmitter) {
+    bool result = ValidateCommandLine(sr, options);
+
+    EXPECT_FALSE(result);
+}
+
+// Test validation - valid configuration
+TEST_F(CommandLineParserTest, ValidateValidConfiguration) {
+    options.tx_site_files.push_back("tx.qth");
+    sr.maxpages = 16;
+
+    bool result = ValidateCommandLine(sr, options);
+
+    EXPECT_TRUE(result);
+}
+
+// Test validation - invalid maxpages
+TEST_F(CommandLineParserTest, ValidateInvalidMaxPages) {
+    options.tx_site_files.push_back("tx.qth");
+    sr.maxpages = 7; // Invalid value
+
+    bool result = ValidateCommandLine(sr, options);
+
+    EXPECT_FALSE(result);
+}
+
+// Test validation - maxpages=1 without HD mode
+TEST_F(CommandLineParserTest, ValidateMaxPages1WithoutHD) {
+    options.tx_site_files.push_back("tx.qth");
+    sr.maxpages = 1;
+    sr.hd_mode = false;
+
+    bool result = ValidateCommandLine(sr, options);
+
+    EXPECT_FALSE(result);
+}
+
+// Test validation - maxpages=1 with HD mode
+TEST_F(CommandLineParserTest, ValidateMaxPages1WithHD) {
+    options.tx_site_files.push_back("tx.qth");
+    sr.maxpages = 1;
+    sr.hd_mode = true;
+
+    bool result = ValidateCommandLine(sr, options);
+
+    EXPECT_TRUE(result);
+}
+
+// Test multiple flags combined
+TEST_F(CommandLineParserTest, MultipleFlagsCombined) {
+    std::vector<std::string> args = {"splat", "-t",  "tx.qth",     "-r",
+                                     "rx.qth", "-hd", "-itwom",     "-imperial",
+                                     "-nf",    "-sc", "-maxpages", "36"};
+    auto argv = MakeArgv(args);
+
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(options.tx_site_files.size(), 1);
+    EXPECT_EQ(options.rx_site_file, "rx.qth");
+    EXPECT_TRUE(sr.hd_mode);
+    EXPECT_EQ(sr.propagation_model, PROP_ITWOM);
+    EXPECT_FALSE(sr.metric);
+    EXPECT_FALSE(sr.fresnel_plot);
+    EXPECT_TRUE(sr.smooth_contours);
+    EXPECT_EQ(sr.maxpages, 36);
+}
+
+// Test conflicting options (coverage and path loss)
+TEST_F(CommandLineParserTest, ConflictingCoverageAndPathLoss) {
+    std::vector<std::string> args = {"splat", "-t", "tx.qth", "-c",
+                                     "10.0",   "-L", "20.0"};
+    auto argv = MakeArgv(args);
+
+    // Parser allows both, but coverage takes precedence (L ignored with warning)
+    bool result = ParseCommandLine(args.size(), argv.data(), sr, options);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sr.coverage);
+    EXPECT_TRUE(sr.LRmap);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a dedicated command-line parser, refactors `main.cpp` to use it with validation, and adds extensive unit tests with build integration.
> 
> - **CLI Parsing**:
>   - New `src/command_line_parser.{h,cpp}` implementing option parsing, help output, and `ValidateCommandLine` (enforces `-maxpages` constraints and presence of TX sites).
>   - `src/main.cpp` refactored to use `CommandLineOptions` and `ParseCommandLine`/`ValidateCommandLine`; replaces ad-hoc parsing and wires parsed filenames through execution paths.
> - **Tests**:
>   - Add `tests/command_line_parser_test.cpp` with broad coverage of flags, clamping, conflicts, and validation.
> - **Build System**:
>   - Include `src/command_line_parser.cpp` in `CMakeLists.txt` and test sources; update references in `src/CMakeLists.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0286a0728669c6bf62e674b96a83ad049d2c8e8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->